### PR TITLE
Fix error handling

### DIFF
--- a/post.js
+++ b/post.js
@@ -21,7 +21,13 @@
     }
   
     if (errBuffer.length) {
-      throw new Error(fromByteArray(errBuffer))
+      var errBufferContents = fromByteArray(errBuffer)
+      var errString = errBufferContents
+      if (errString.indexOf(':') > -1) {
+        var parts = errString.split(':')
+        errString = parts[parts.length - 1].trim()
+      }
+      throw new Error(errString)
     }
 
     return ''

--- a/post.js
+++ b/post.js
@@ -14,7 +14,8 @@
   
     // calling main closes stdout, so we reopen it here:
     FS.streams[1] = FS.open('/dev/stdout', 577, 0)
-  
+    FS.streams[2] = FS.open('/dev/stderr', 577, 0)
+
     if (outBuffer.length) {
       return fromByteArray(outBuffer)
     }


### PR DESCRIPTION
This PR re-opens the `stderr` stream as well and returns a proper error message.

jq starts the error message with "jq: error (at <stdin>:0): ". This part doesn't really contain any information that is helpful for us so we'll just cut it out.