### PR TITLE
fix jq main options: reset in main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ jq/configure: .gitmodules
 	git submodule update --init
 	cd jq && \
 	  git submodule update --init && \
+	  patch -sf src/main.c <../main.patch && \
 	  autoreconf -fi
 
 jq/jq.o: jq/configure

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ jq/configure: .gitmodules
 	git submodule update --init
 	cd jq && \
 	  git submodule update --init && \
-	  patch -sf src/main.c <../main.patch && \
+	  patch -st src/main.c <../main.patch && \
 	  autoreconf -fi
 
 jq/jq.o: jq/configure

--- a/main.patch
+++ b/main.patch
@@ -1,0 +1,12 @@
+diff --git a/src/main.c b/src/main.c
+index b154689..ebaae67 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -245,6 +245,7 @@ int main(int argc, char* argv[]) {
+   int badwrite;
+   jv ARGS = jv_array(); /* positional arguments */
+   jv program_arguments = jv_object(); /* named arguments */
++  options = 0; // reset global var
+ 
+ #ifdef WIN32
+   fflush(stdout);


### PR DESCRIPTION
the jq/src/main.c
has a global variable `options`, which can't be reset at js.

so I add a main.patch for `options` reset

#15 