### PR TITLE
Disable emscripten PTHREAD usage, so SharedArrayBuffer is no longer used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ jq/Makefile: jq/configure
 
 jq/jq: jq/Makefile pre.js post.js extern-post.js
 	rm -f $@ # needed for emcc to replace existing file
-	cd jq && env CCFLAGS=-O2 emmake make V=1 VERBOSE=1 LDFLAGS="-all-static -s EXPORTED_RUNTIME_METHODS='[\"callMain\"]' -s ALLOW_MEMORY_GROWTH=1 -s MODULARIZE=1 -s EXPORT_NAME=jq -s WASM=1 --pre-js ../pre.js --post-js ../post.js --extern-post-js ../extern-post.js" CCFLAGS=-O2 -j4
+	cd jq && env CCFLAGS=-O2 emmake make V=1 VERBOSE=1 LDFLAGS="-all-static -s EXPORTED_RUNTIME_METHODS='[\"callMain\"]' -s ALLOW_MEMORY_GROWTH=1 -s MODULARIZE=1 -s USE_PTHREADS=0 -s EXPORT_NAME=jq -s WASM=1 --pre-js ../pre.js --post-js ../post.js --extern-post-js ../extern-post.js" CCFLAGS=-O2 -j4
 
 jq.js: jq/jq jq.wasm
 	cp -f jq/jq ./jq.js


### PR DESCRIPTION
- the use of SharedArrayBuffer creates issues, since now the browser requires specific CORS headers to be used. 

- SharedArrayBuffer usage in jq.js is generated because of emscripten enabeling PTHREAD support (in one way or another)

- Asfaik PTHREAD features are not actually used so it won't be slower or not working

- Explicitly disabling PTHREAD usage by emscripten in the makefile prevents SharedArrayBuffer code from being generated, now it works as expected out of the box again with ./node_modules/live-server/live-server.js --open="index.html"