### PR TITLE
fix(slurp): properly replace filter to avoid collisions

### DIFF
--- a/post.js
+++ b/post.js
@@ -52,7 +52,7 @@ function raw(jsonstring, filter, flags) {
       flags[i] = "--slurpfile";
       
       if (typeof filter === 'string') {
-        filter = filter.replaceAll(argName, argName + '[0]');
+        filter = argName + '[0] as ' + argName + ' | ' + filter;
       }
 
       FS.writeFile(fileName, flags[fileIndex]);


### PR DESCRIPTION
given the filter `$abc $abcd`
and the arguments --argjson abc "" --argjson abcd ""

this was wrongly transformed to
	   `$abc[0] $abc[0]d`
instead of `$abc[0] $abcd[0]`.

this PR transforms the expression to
`$abc[0] as $abc | $abcd[0] as $abcd | $abc $abcd`
which is much safer and works every time